### PR TITLE
Add Java 16

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=16.0.1-open

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,7 +49,7 @@ blocks:
           value: 'postgresql://postgres:postgres@localhost:5432/fakedata_test'
       prologue:
         commands:
-          - sem-version java 11
+          - sem-version java 16
           - sem-service start postgres 13 --username=postgres --password=password --db=fakedata_test
           - checkout
           - cache restore

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ blocks:
       jobs:
         - name: Maven install and cache
           commands:
-            - java -version
+            - sem-version java 16
             - checkout
             - cache restore
             - 'mvn -q dependency:go-offline test-compile'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ blocks:
       jobs:
         - name: Maven install and cache
           commands:
-            - sem-version java 11
+            - java -version
             - checkout
             - cache restore
             - 'mvn -q dependency:go-offline test-compile'

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.5.RELEASE</version>
+        <version>2.5.2</version>
         <relativePath/>
     </parent>
 
@@ -16,7 +16,7 @@
     <description>Public API for QA</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>16</java.version>
         <version.number>${git.closest.tag.name}-local</version.number>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,9 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>3.1.2</version>
                 <configuration>
+                    <from>
+                        <image>adoptopenjdk:16-jre@sha256:acc99f88a18a9954da4f9605c715d907c41fe5648e270ed0f77c2a0459f55931</image>
+                    </from>
                     <to>
                         <image>docker.io/pythoninja/randomicu</image>
                         <tags>
@@ -103,23 +106,13 @@
                     </to>
                     <container>
                         <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
-                        <jvmFlags>
-                            <jvmFlag>-server</jvmFlag>
-                            <jvmFlag>-XX:+UseContainerSupport</jvmFlag>
-                            <jvmFlag>-Xmx300m</jvmFlag>
-                            <jvmFlag>-Xss512k</jvmFlag>
-                            <jvmFlag>-XX:CICompilerCount=2</jvmFlag>
-                            <jvmFlag>-Dfile.encoding=UTF-8</jvmFlag>
-                        </jvmFlags>
                         <args>
                             <arg>$JAVA_OPTS</arg>
                             <arg>-server</arg>
-                            <arg>-XX:+UseContainerSupport</arg>
-                            <arg>-Xmx300m</arg>
-                            <arg>-Xss512k</arg>
-                            <arg>-XX:CICompilerCount=2</arg>
+                            <arg>-XX:CICompilerCount=4</arg>
                             <arg>-Dfile.encoding=UTF-8</arg>
                         </args>
+                        <mainClass>icu.random.Application</mainClass>
                     </container>
                 </configuration>
                 <executions>


### PR DESCRIPTION
This PR moves project to Java 16 and stays with Jib.

1. Base image: `adoptopenjdk:16-jre@sha256:acc99f88a18a9954da4f9605c715d907c41fe5648e270ed0f77c2a0459f55931`
2. App startup optimization
3. Bump Spring Boot
4. Bump Jib